### PR TITLE
docs: fix data export path

### DIFF
--- a/docs/lastfm-doc.html
+++ b/docs/lastfm-doc.html
@@ -422,11 +422,11 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 </section>
 <section id="exporting-the-data" class="level1">
 <h1>Exporting the data</h1>
-<p>The data gets exported to a csv to use in other software.</p>
+<p>The data gets exported to a csv in <code>data/scrobbles.csv</code> for use in other software.</p>
 <div class="cell">
 <div class="sourceCode cell-code" id="cb9"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb9-1"><a href="#cb9-1" aria-hidden="true" tabindex="-1"></a><span class="co"># | label: data-export</span></span>
 <span id="cb9-2"><a href="#cb9-2" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb9-3"><a href="#cb9-3" aria-hidden="true" tabindex="-1"></a><span class="fu">write.csv</span>(scrobbles, <span class="st">'../data/scrobbles.csv'</span>)</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
+<span id="cb9-3"><a href="#cb9-3" aria-hidden="true" tabindex="-1"></a><span class="fu">write.csv</span>(scrobbles, <span class="st">'data/scrobbles.csv'</span>)</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
 </div>
 </section>
 

--- a/docs/lastfm-doc.qmd
+++ b/docs/lastfm-doc.qmd
@@ -70,12 +70,12 @@ scrobbles <-
 
 # Exporting the data
 
-The data gets exported to a csv to use in other software. 
+The data gets exported to a csv in `data/scrobbles.csv` for use in other software.
 
 ```{r}
 # | label: data-export
 
-write.csv(scrobbles, '../data/scrobbles.csv')
+write.csv(scrobbles, 'data/scrobbles.csv')
 
 ```
 


### PR DESCRIPTION
## Summary
- fix data export instructions in documentation

## Testing
- `grep -n "data/scrobbles.csv" -n docs/lastfm-doc.html | head`

------
https://chatgpt.com/codex/tasks/task_b_6861fa479240832d944015b1ed4f5131