### PR TITLE
Add flexdashboard shiny script

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,10 @@ The obtainment, cleaning and preliminary analysis of the data was done through R
 
 You may see the main visualization part of the project in my [Tableau Public account](https://public.tableau.com/app/profile/dsanchezp18/viz/VisualizingScrobblesfromLast_fm/VisualizingListeningTrends).
 
+An interactive Shiny dashboard built with the **flexdashboard** package is also
+available. Launch it with:
+
+```r
+rmarkdown::run("scripts/scrobbles_flexdashboard.Rmd")
+```
+

--- a/scripts/scrobbles_flexdashboard.Rmd
+++ b/scripts/scrobbles_flexdashboard.Rmd
@@ -1,0 +1,94 @@
+---
+title: "Last.fm Scrobbles Dashboard"
+output:
+  flexdashboard::flex_dashboard:
+    orientation: columns
+    vertical_layout: fill
+runtime: shiny
+---
+
+```{r setup, include=FALSE}
+library(flexdashboard)
+library(readr)
+library(dplyr)
+library(ggplot2)
+
+# load scrobbles data
+scrobbles <- read_csv("../data/scrobbles.csv", show_col_types = FALSE)
+scrobbles$date <- as.POSIXct(scrobbles$date, tz = "UTC")
+```
+
+Column {data-width=250}
+-------------------------------------
+
+### Total scrobbles
+
+```{r}
+valueBox(nrow(scrobbles), caption = "Scrobbles", icon = "music")
+```
+
+### Top artist
+
+```{r}
+top_artist <- scrobbles %>%
+  count(artist, sort = TRUE) %>%
+  slice(1)
+valueBox(top_artist$n, caption = top_artist$artist, icon = "person-fill")
+```
+
+Column
+-------------------------------------
+
+### Top Artists
+
+```{r}
+renderPlot({
+  scrobbles %>%
+    count(artist, sort = TRUE) %>%
+    top_n(10) %>%
+    mutate(artist = reorder(artist, n)) %>%
+    ggplot(aes(artist, n)) +
+    geom_col(fill = "steelblue") +
+    coord_flip() +
+    labs(x = NULL, y = "Scrobbles")
+})
+```
+
+### Listening over time
+
+```{r}
+renderPlot({
+  scrobbles %>%
+    mutate(day = as.Date(date)) %>%
+    count(day) %>%
+    ggplot(aes(day, n)) +
+    geom_line(color = "darkred") +
+    labs(x = "Date", y = "Scrobbles per day")
+})
+```
+
+### Tracks for selected artist
+
+```{r}
+inputPanel(
+  selectizeInput("artist_select", "Artist",
+                 choices = sort(unique(scrobbles$artist)),
+                 multiple = FALSE)
+)
+
+renderPlot({
+  selected <- scrobbles
+  if (!is.null(input$artist_select) && input$artist_select != "") {
+    selected <- selected %>% filter(artist == input$artist_select)
+  }
+  selected %>%
+    count(track, sort = TRUE) %>%
+    top_n(10) %>%
+    mutate(track = reorder(track, n)) %>%
+    ggplot(aes(track, n)) +
+    geom_col(fill = "darkgreen") +
+    coord_flip() +
+    labs(x = NULL, y = "Scrobbles",
+         title = paste0("Top Tracks - ", input$artist_select))
+})
+```


### PR DESCRIPTION
## Summary
- add `scrobbles_flexdashboard.Rmd` for a Shiny dashboard using flexdashboard
- document how to launch the dashboard in the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6861fe09dd44832d97e6e842724e99bb