### PR TITLE
Add flexdashboard shiny QMD

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,10 @@ The obtainment, cleaning and preliminary analysis of the data was done through R
 
 You may see the main visualization part of the project in my [Tableau Public account](https://public.tableau.com/app/profile/dsanchezp18/viz/VisualizingScrobblesfromLast_fm/VisualizingListeningTrends).
 
+An interactive Shiny dashboard built with the **flexdashboard** package is also
+available. Launch it with:
+
+```r
+rmarkdown::run("scripts/scrobbles_flexdashboard.Rmd")
+```
+

--- a/scripts/scrobbles_flexdashboard.qmd
+++ b/scripts/scrobbles_flexdashboard.qmd
@@ -1,0 +1,128 @@
+---
+title: "Last.fm Scrobbles Dashboard"
+format:
+  flexdashboard:
+    orientation: columns
+    vertical-layout: fill
+server: shiny
+---
+
+```{r setup, include=FALSE}
+library(flexdashboard)
+library(readr)
+library(dplyr)
+library(ggplot2)
+
+scrobbles <- read_csv("../data/scrobbles.csv", show_col_types = FALSE)
+scrobbles$date <- as.POSIXct(scrobbles$date, tz = "UTC")
+scrobbles$day <- as.Date(scrobbles$date)
+scrobbles$year <- format(scrobbles$date, "%Y")
+scrobbles$weekday <- weekdays(scrobbles$date)
+scrobbles$hour <- format(scrobbles$date, "%H")
+```
+
+Column {data-width=250}
+-------------------------------------
+
+```{r}
+valueBox(nrow(scrobbles), caption = "Scrobbles", icon = "music")
+```
+
+```{r}
+  top_artist <- scrobbles %>%
+    count(artist, sort = TRUE) %>%
+    slice(1)
+  valueBox(top_artist$n, caption = top_artist$artist, icon = "person-fill")
+```
+
+```{r}
+inputPanel(
+  selectInput("year_filter", "Year", choices = c("All", unique(scrobbles$year)))
+)
+```
+
+Column
+-------------------------------------
+
+### Top Artists
+
+```{r}
+renderPlot({
+  data <- scrobbles
+  if (!is.null(input$year_filter) && input$year_filter != "All") {
+    data <- filter(scrobbles, year == input$year_filter)
+  }
+  data %>%
+    count(artist, sort = TRUE) %>%
+    top_n(10) %>%
+    mutate(artist = reorder(artist, n)) %>%
+    ggplot(aes(artist, n)) +
+    geom_col(fill = "steelblue") +
+    coord_flip() +
+    labs(x = NULL, y = "Scrobbles") +
+    theme_minimal()
+})
+```
+
+### Listening Over Time
+
+```{r}
+renderPlot({
+  data <- scrobbles
+  if (!is.null(input$year_filter) && input$year_filter != "All") {
+    data <- filter(scrobbles, year == input$year_filter)
+  }
+  data %>%
+    count(day) %>%
+    ggplot(aes(day, n)) +
+    geom_line(color = "darkred") +
+    labs(x = "Date", y = "Scrobbles per day") +
+    theme_minimal()
+})
+```
+
+### Listening Heatmap
+
+```{r}
+renderPlot({
+  data <- scrobbles
+  if (!is.null(input$year_filter) && input$year_filter != "All") {
+    data <- filter(scrobbles, year == input$year_filter)
+  }
+  data %>%
+    count(weekday, hour) %>%
+    mutate(weekday = factor(weekday, levels = c("Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"))) %>%
+    ggplot(aes(hour, weekday, fill = n)) +
+    geom_tile() +
+    scale_fill_gradient(low = "#fee0d2", high = "#de2d26") +
+    labs(x = "Hour of Day", y = NULL, fill = "Scrobbles") +
+    theme_minimal()
+})
+```
+
+### Tracks for Selected Artist
+
+```{r}
+inputPanel(
+  selectizeInput("artist_select", "Artist", choices = sort(unique(scrobbles$artist)), multiple = FALSE)
+)
+
+renderPlot({
+  data <- scrobbles
+  if (!is.null(input$year_filter) && input$year_filter != "All") {
+    data <- filter(data, year == input$year_filter)
+  }
+  if (!is.null(input$artist_select) && input$artist_select != "") {
+    data <- filter(data, artist == input$artist_select)
+  }
+  data %>%
+    count(track, sort = TRUE) %>%
+    top_n(10) %>%
+    mutate(track = reorder(track, n)) %>%
+    ggplot(aes(track, n)) +
+    geom_col(fill = "darkgreen") +
+    coord_flip() +
+    labs(x = NULL, y = "Scrobbles", title = paste0("Top Tracks - ", input$artist_select)) +
+    theme_minimal()
+})
+```


### PR DESCRIPTION
## Summary
- replace flexdashboard `Rmd` with Quarto `qmd`
- include additional plots and filters for a Tableau-like layout

## Testing
- `git status --short`
- `R --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6861fe09dd44832d97e6e842724e99bb